### PR TITLE
Add timer recovery and auto-save features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ A Bubble Tea TUI to track time per Linear issue, rounding to the next quarter ho
 4. Install: `go install .` (the binary will be available as `unitrack` in your `$GOPATH/bin`)
 5. Create `~/.config/unitrack/unitrack.json`:
    ```json
-   { "api_key": "YOUR_LINEAR_API_KEY", "prefix": "UE" }
+   {
+     "api_key": "YOUR_LINEAR_API_KEY",
+     "prefix": "UE",
+     "timer_expire_days": 5
+   }
    ```
    - `prefix` configures the project key in issue IDs (e.g. "UE-1234").
+   - `timer_expire_days` (optional) sets how many days before saved timers expire (default: 5).
 
 ## Usage
 
@@ -27,6 +32,18 @@ A Bubble Tea TUI to track time per Linear issue, rounding to the next quarter ho
 - Previous full issue IDs are saved in history; cycle them with `Up`/`Down` arrows.
 - Quit with `q` or `ctrl+c`.
 - All logs/output are in `$HOME/.config/unitrack/unitrack.log`.
+
+### Auto-save & Recovery
+
+- The timer state is automatically saved every minute to `~/.config/unitrack/saved_timer_<issue_id>.json`
+- If you start tracking an issue that has a saved timer, you'll be prompted to either:
+  - Continue from the saved time (press `y`)
+  - Start fresh and discard the saved time (press `n`)
+- Saved timers are automatically deleted when:
+  - You submit the time to Linear
+  - You cancel a timer
+  - The saved timer is older than the configured expiration (default: 5 days)
+- This feature helps recover from crashes or accidental closures
 
 ### Notes
 - Customize the prefix for issue IDs in the config (e.g. "UI" for UI-1234).


### PR DESCRIPTION
This pull request adds a robust auto-save and recovery feature for timers in the Linear issue tracker TUI, improving reliability in case of crashes or accidental closures. It introduces periodic saving of timer state, recovery prompts when restarting tracking, and automatic cleanup of expired or submitted timers. The configuration and documentation are updated to reflect these changes.

### Auto-save & Recovery Feature

* Timer state is now automatically saved every minute to a per-issue file (`saved_timer_<issue_id>.json`). When starting a timer for an issue, the app checks for a saved timer and prompts the user to continue from the saved time or start fresh. Saved timers are deleted upon submission, cancellation, or expiration. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R40-R44) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R109-R116) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R194-R199) [[4]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R226-R256) [[5]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R280-R283) [[6]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R388-R455)

### Configuration and Documentation

* Added a new config option `timer_expire_days` to control how long saved timers persist (default: 5 days), and updated the `README.md` to document this feature and its usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R47) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R313)

### Code Structure and Cleanup

* Refactored timer recovery logic into a new screen state (`screenRecoverTimer`) and associated model fields, improving code clarity and separation of concerns for the recovery workflow. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R23) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R40-R44)

### Timer Lifecycle Improvements

* Ensured that saved timers are properly deleted when submitting or cancelling a timer, and when a saved timer is expired, preventing accumulation of stale files. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R179) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R210-R211) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R388-R455)